### PR TITLE
changed http auth header to use bearer & error codehandling in getOrCreateIndex

### DIFF
--- a/vendor/meilisearch/meilisearch-php/src/Delegates/HandlesIndex.php
+++ b/vendor/meilisearch/meilisearch-php/src/Delegates/HandlesIndex.php
@@ -61,7 +61,7 @@ trait HandlesIndex
         try {
             $index = $this->getIndex($uid);
         } catch (ApiException $e) {
-            if (\is_array($e->httpBody) && 'index_not_found' === $e->httpBody['errorCode']) {
+            if (\is_array($e->httpBody) && 'index_not_found' === $e->httpBody['code']) {
                 $index = $this->createIndex($uid, $options);
             } else {
                 throw $e;

--- a/vendor/meilisearch/meilisearch-php/src/Http/Client.php
+++ b/vendor/meilisearch/meilisearch-php/src/Http/Client.php
@@ -61,7 +61,7 @@ class Client implements Http
         $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $this->headers = array_filter([
             'Content-type' => 'application/json',
-            'X-Meili-API-Key' => $this->apiKey,
+            'Authorization' => 'Bearer '.$this->apiKey,
         ]);
     }
 


### PR DESCRIPTION
Due to some minor changes in Meilisearch the plugin was no longer connecting to the api. I've updated to code in 2 places so it works again.

The auth header changed in their api to a Bearer token, see https://docs.meilisearch.com/reference/errors/error_codes.html#missing-authorization-header

The httpBody field name in the ApiException changed from 'errorCode' to 'code'.

Thank you for making something for Wordpress and Meilisearch that WORKS!